### PR TITLE
Fix deprecated scipy calls

### DIFF
--- a/antiglitch/utils.py
+++ b/antiglitch/utils.py
@@ -16,7 +16,7 @@ def center(data):
 
 def downsample_invasd(invasd, tlen=1024):
     """Reduce frequency resolution of the inverse ASD to a given number of time samples"""
-    tmp = np.abs(rfft(sig.hann(tlen)*np.roll(irfft(invasd), tlen//2)[:tlen]))
+    tmp = np.abs(rfft(sig.windows.hann(tlen)*np.roll(irfft(invasd), tlen//2)[:tlen]))
     tmp[0] = 0.
     return tmp
 
@@ -29,7 +29,7 @@ def extract_glitch(npz, halfwidth=512):
     invasd = ((4096.*npz['psd'])**-0.5)[:4097]
     invasd[:10] = 0.
     filt = np.zeros(4*8192)
-    filt[:8192] = sig.hann(8192)*np.roll(irfft(invasd), 4096)
+    filt[:8192] = sig.windows.hann(8192)*np.roll(irfft(invasd), 4096)
     fdfilt = np.abs(rfft(filt)) # This is a one-second resolution invasd
 
     whts = irfft(fdfilt*rfft(npz['data']))


### PR DESCRIPTION
The windows in `scipy.signal` were moved to `scipy.signal.windows` so the existing calls raised errors.